### PR TITLE
fix tmux script

### DIFF
--- a/tmux.sh
+++ b/tmux.sh
@@ -9,7 +9,7 @@ create_tmux_session() {
 		send-keys "sh ./run.sh" C-m \; \
 		new-window -n "Dev" \; \
 		send-keys "nvim main.go" C-m \; \
-		split-window -v \; \
+		split-window -v \;
 }
 
 if ! tmux has-session -t "learnngrow" 2>/dev/null; then


### PR DESCRIPTION
Oh no it appears I have accidentally left an extra backslash ('\') which
has prevented the script from running successfully. It is because the
backslash character 'escaped' the new-line character and the subsequent
closing brace ('}'), and the 'unclosed' braces very much *confused* the
shell, running the script. Cheers mate
